### PR TITLE
maintain nanosecond precision for time/duration

### DIFF
--- a/include/ros_type_introspection/variant.hpp
+++ b/include/ros_type_introspection/variant.hpp
@@ -97,6 +97,7 @@ inline DST VarNumber::convert() const
 
     case INT16:  convert_impl<int16_t, DST>(*reinterpret_cast<const int16_t*>( _raw_data), target  ); break;
     case INT32:  convert_impl<int32_t, DST>(*reinterpret_cast<const int32_t*>( _raw_data), target  ); break;
+    case DURATION:
     case INT64:  convert_impl<int64_t, DST>(*reinterpret_cast<const int64_t*>( _raw_data), target  ); break;
 
     case BOOL:
@@ -105,6 +106,7 @@ inline DST VarNumber::convert() const
 
     case UINT16:  convert_impl<uint16_t, DST>(*reinterpret_cast<const uint16_t*>( _raw_data), target  ); break;
     case UINT32:  convert_impl<uint32_t, DST>(*reinterpret_cast<const uint32_t*>( _raw_data), target  ); break;
+    case TIME:
     case UINT64:  convert_impl<uint64_t, DST>(*reinterpret_cast<const uint64_t*>( _raw_data), target  ); break;
 
     case FLOAT32:  convert_impl<float, DST>(*reinterpret_cast<const float*>( _raw_data), target  ); break;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -192,17 +192,17 @@ ROSType::ROSType(const std::string &name):
     else if(_msg_name.compare( "time" ) == 0 ) {
         _id = RosIntrospection::TIME;
         _deserialize_impl = [](uint8_t** buffer) {
-            double sec  = (double) ReadFromBuffer<uint32_t>(buffer);
-            double nsec = (double) ReadFromBuffer<uint32_t>(buffer);
-            return (double)( sec + nsec*1e-9);
+            const uint32_t sec  = ReadFromBuffer<uint32_t>(buffer);
+            const uint32_t nsec = ReadFromBuffer<uint32_t>(buffer);
+            return static_cast<uint64_t>(sec * 1000000000ull + nsec);
         };
     }
     else if(_msg_name.compare( "duration" ) == 0 ) {
         _id = RosIntrospection::DURATION;
         _deserialize_impl = [](uint8_t** buffer) {
-            double sec  = (double) ReadFromBuffer<uint32_t>(buffer);
-            double nsec = (double) ReadFromBuffer<uint32_t>(buffer);
-            return (double)( sec + nsec*1e-9 );
+            const int32_t sec  = ReadFromBuffer<int32_t>(buffer);
+            const int32_t nsec = ReadFromBuffer<int32_t>(buffer);
+            return static_cast<uint64_t>(sec * 1000000000ll + nsec);
         };
     }
     else if(_msg_name.compare( "string" ) == 0 ) {


### PR DESCRIPTION
`double` cannot represent nanoseconds since epoch, so precision is lost.


Also, `ROS` allows `Duration` to be negative.
I'm unsure of how it is serialized though, so this may not be correct.

I was able to maintain nanosecond precision in my project now though with
```
ros::Time().fromNSec(value.convert<uint64_t>());
```