### PR TITLE
One vector to contain them all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,15 +65,15 @@ include_directories(
 target_link_libraries(ros_type_introspection ${catkin_LIBRARIES})
 
 ## Declare a C++ executable
-#add_executable(ros_introspection_benchmark src/benchmark.cpp)
-#add_dependencies(ros_introspection_benchmark
-#    ${${PROJECT_NAME}_EXPORTED_TARGETS}
-#    ${catkin_EXPORTED_TARGETS})
+add_executable(ros_introspection_benchmark src/tests/benchmark.cpp)
+add_dependencies(ros_introspection_benchmark
+    ${${PROJECT_NAME}_EXPORTED_TARGETS}
+    ${catkin_EXPORTED_TARGETS})
 
-#target_link_libraries(ros_introspection_benchmark
-# ${catkin_LIBRARIES}
-#  ros_type_introspection
-#)
+target_link_libraries(ros_introspection_benchmark
+ ${catkin_LIBRARIES}
+  ros_type_introspection
+)
 
 
 #############
@@ -91,7 +91,11 @@ install(TARGETS ros_type_introspection
    RUNTIME DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
  )
 
-
+install(TARGETS ros_introspection_benchmark 
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+ 
 ## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/include/ros_type_introspection/builtin_types.hpp
+++ b/include/ros_type_introspection/builtin_types.hpp
@@ -5,6 +5,14 @@
 #include <string>
 #include <ros/ros.h>
 
+#if 1
+// Faster, but might need more testing
+typedef ssoX::basic_string<char> SString;
+#else
+// slightly slower but safer option. More convenient during debug
+typedef std::string SString;
+#endif
+
 namespace RosIntrospection{
 
 
@@ -68,6 +76,7 @@ template <> inline BuiltinType getType<float>()  {  return FLOAT32; }
 template <> inline BuiltinType getType<double>() {  return FLOAT64; }
 
 template <> inline BuiltinType getType<std::string>() {  return STRING; }
+template <> inline BuiltinType getType<SString>() {  return STRING; }
 
 template <> inline BuiltinType getType<ros::Time>()     {  return TIME; }
 template <> inline BuiltinType getType<ros::Duration>() {  return DURATION; }

--- a/include/ros_type_introspection/deserializer.hpp
+++ b/include/ros_type_introspection/deserializer.hpp
@@ -88,12 +88,11 @@ typedef struct{
   /// Tree that the StringTreeLeaf(s) refer to.
   StringTree tree;
 
-  /// List of all those parsed fields that can be represented by a builtin value different from "string".
+  /// List of all those parsed fields, contains both numerical values and strings.
   /// This list will be filled by the funtion buildRosFlatType.
-  std::vector< std::pair<StringTreeLeaf, VarNumber> > value;
+  std::vector< std::pair<StringTreeLeaf, Variant> > value;
 
-  /// Ñist of all those parsed fields that can be represented by a builtin value equal to "string".
-  /// This list will be filled by the funtion buildRosFlatType.
+  /// This is not used anymore, was not removed yet to to renamer.cpp still depending on it
   std::vector< std::pair<StringTreeLeaf, SString> > name;
 
   // Not used yet

--- a/include/ros_type_introspection/parser.hpp
+++ b/include/ros_type_introspection/parser.hpp
@@ -102,9 +102,9 @@ public:
     return this->baseName() < other.baseName();
   }
 
-  VarNumber deserializeFromBuffer(uint8_t** buffer) const
+  Variant deserializeFromBuffer(uint8_t** buffer) const
   {
-      if(!_deserialize_impl){ return VarNumber(); }
+      if(!_deserialize_impl){ return Variant(); }
       else{
           return _deserialize_impl(buffer);
       }
@@ -117,7 +117,7 @@ protected:
   SString _base_name;
   SString _msg_name;
   SString _pkg_name;
-  boost::function<VarNumber(uint8_t** buffer)> _deserialize_impl;
+  boost::function<Variant(uint8_t** buffer)> _deserialize_impl;
 
 };
 

--- a/include/ros_type_introspection/renamer.hpp
+++ b/include/ros_type_introspection/renamer.hpp
@@ -124,7 +124,7 @@ private:
 
 typedef std::map< std::string, std::vector< RosIntrospection::SubstitutionRule > > SubstitutionRuleMap;
 
-typedef std::vector< std::pair<std::string, VarNumber>> RenamedValues;
+typedef std::vector< std::pair<std::string, Variant>> RenamedValues;
 
 void applyNameTransform(const std::vector<SubstitutionRule> &rules,
                         const ROSTypeFlat& container_source,

--- a/include/ros_type_introspection/variant.hpp
+++ b/include/ros_type_introspection/variant.hpp
@@ -6,43 +6,55 @@
 #include "ros_type_introspection/builtin_types.hpp"
 #include "ros_type_introspection/details/exceptions.hpp"
 #include "ros_type_introspection/details/conversion_impl.hpp"
+#include <boost/any.hpp>
 
+#if 1
+// Faster, but might need more testing
+typedef ssoX::basic_string<char> SString;
+#else
+// slightly slower but safer option. More convenient during debug
+typedef std::string SString;
+#endif
 
 namespace RosIntrospection
 {
 
-class VarNumber
+class Variant
 {
 
 public:
 
-  VarNumber() {
-    _raw_data[8] = OTHER;
+  Variant() {
+    _type = OTHER;
   }
-
-  template<typename T> VarNumber(T value);
+   
+// // 
+  template<typename T> Variant(T value);
 
   BuiltinType getTypeID() const;
-
+  
   template<typename T> T convert( ) const;
+  
+  boost::any auto_convert() const;
 
   template<typename T> T extract( ) const;
 
   template <typename T> void assign(const T& value);
 
 private:
-  uint8_t _raw_data[9];
+  std::vector<uint8_t> _raw_data;
+  uint8_t  _type;
 
 };
 
 template <typename T> inline
-bool operator ==(const VarNumber& var, const T& num)
+bool operator ==(const Variant& var, const T& num)
 {
   return var.convert<T>() == num;
 }
 
 template <typename T> inline
-bool operator ==(const T& num, const VarNumber& var)
+bool operator ==(const T& num, const Variant& var)
 {
   return var.convert<T>() == num;
 }
@@ -51,108 +63,158 @@ bool operator ==(const T& num, const VarNumber& var)
 
 
 template<typename T>
-inline VarNumber::VarNumber(T value)
-{
+inline Variant::Variant(T value) {
   static_assert (std::numeric_limits<T>::is_specialized ||
                  std::is_same<T, ros::Time>::value ||
-                 std::is_same<T, ros::Duration>::value
+                 std::is_same<T, ros::Duration>::value ||
+                 std::is_same<T, SString>::value
                  , "not a valid type");
   assign(value);
 }
 
-inline BuiltinType VarNumber::getTypeID() const {
-  return static_cast<BuiltinType>(_raw_data[8]);
+inline BuiltinType Variant::getTypeID() const {
+  return static_cast<BuiltinType>(_type);
 }
 
+
 template<typename T>
-inline T VarNumber::extract( ) const
+inline T Variant::extract( ) const
 {
   static_assert (std::numeric_limits<T>::is_specialized ||
                  std::is_same<T, ros::Time>::value ||
-                 std::is_same<T, ros::Duration>::value
+                 std::is_same<T, ros::Duration>::value ||
+                 std::is_same<T, SString>::value
                  , "not a valid type");
-
   if( getTypeID() != RosIntrospection::getType<T>() )
   {
-    throw TypeException("VarNumber::extract -> wrong type");
-  }
-  return * reinterpret_cast<const T*>( _raw_data );
+    throw TypeException("Variant::extract -> wrong type");
+  } 
+  return * reinterpret_cast<const T*>( &_raw_data [0]);
+}
+
+template <>
+inline void Variant::assign(const SString& value)
+{
+  //No assert necessary here as we know data is a SString
+  _raw_data.resize(sizeof(value)/sizeof(uint8_t));
+  *reinterpret_cast<SString *>( &_raw_data[0] ) =  value;
+  _type = STRING ;
 }
 
 template <typename T>
-inline void VarNumber::assign(const T& value)
+inline void Variant::assign(const T& value)
 {
   static_assert (std::numeric_limits<T>::is_specialized ||
                  std::is_same<T, ros::Time>::value ||
-                 std::is_same<T, ros::Duration>::value
+                 std::is_same<T, ros::Duration>::value ||
+                 std::is_same<T, SString>::value
                  , "not a valid type");
 
-  *reinterpret_cast<T *>( _raw_data ) =  value;
-  _raw_data[8] = RosIntrospection::getType<T>() ;
+  _raw_data.resize(sizeof(T));
+  *reinterpret_cast<T *>( &_raw_data [0]) =  value;
+  _type = RosIntrospection::getType<T>() ;
 }
 
-template<typename DST> inline DST VarNumber::convert() const
+inline boost::any Variant::auto_convert() const
+{
+  using namespace RosIntrospection::details;
+  boost::any target;
+  //------
+    switch( _type )
+  {
+    
+  case CHAR:
+  case INT8:   int64_t tmp1; convert_impl<int8_t,  int64_t>(*reinterpret_cast<const int8_t*>( &_raw_data [0]), tmp1 ); target = tmp1; break;
+
+  case INT16:  int64_t tmp2; convert_impl<int16_t, int64_t>(*reinterpret_cast<const int16_t*>( &_raw_data [0]), tmp2  ); target = tmp2;break;
+  case INT32:  int64_t tmp3; convert_impl<int32_t, int64_t>(*reinterpret_cast<const int32_t*>( &_raw_data [0]), tmp3  ); target = tmp3;break;
+  case INT64:  int64_t tmp4; convert_impl<int64_t, int64_t>(*reinterpret_cast<const int64_t*>( &_raw_data [0]), tmp4  ); target = tmp4;break;
+
+  case BOOL:
+  case BYTE:
+  case UINT8:   uint64_t tmp5; convert_impl<uint8_t,  uint64_t>(*reinterpret_cast<const uint8_t*>( &_raw_data [0]), tmp5  ); target = tmp5;break;
+
+  case UINT16:  uint64_t tmp6; convert_impl<uint16_t, uint64_t>(*reinterpret_cast<const uint16_t*>( &_raw_data [0]), tmp6  ); target = tmp6;break;
+  case UINT32:  uint64_t tmp7; convert_impl<uint32_t, uint64_t>(*reinterpret_cast<const uint32_t*>( &_raw_data [0]), tmp7  ); target = tmp7;break;
+  case UINT64:  uint64_t tmp8; convert_impl<uint64_t, uint64_t>(*reinterpret_cast<const uint64_t*>( &_raw_data [0]), tmp8  ); target = tmp8;break;
+
+  case FLOAT32:  double tmp9; convert_impl<float, double>(*reinterpret_cast<const float*>( &_raw_data [0]), tmp9  ); target = tmp9;break;
+  case FLOAT64:  double tmp10; convert_impl<double, double>(*reinterpret_cast<const double*>( &_raw_data [0]), tmp10  ); target = tmp10;break;
+  
+  case DURATION: target = extract<ros::Duration>().toSec(); break;
+  case TIME: target = extract<ros::Time>().toSec(); break;
+
+  case STRING: target = extract<SString>(); break;
+  
+  default:  throw TypeException("Variant::convert -> cannot convert type" + std::to_string(_type)); break;
+
+  }
+  return  target;
+  
+}
+
+template<typename DST> inline DST Variant::convert() const
 {
   using namespace RosIntrospection::details;
   DST target;
 
   //----------
-  switch( _raw_data[8] )
+  switch( _type )
   {
+    
   case CHAR:
-  case INT8:   convert_impl<int8_t,  DST>(*reinterpret_cast<const int8_t*>( _raw_data), target  ); break;
+  case INT8:   convert_impl<int8_t,  DST>(*reinterpret_cast<const int8_t*>( &_raw_data [0]), target  ); break;
 
-  case INT16:  convert_impl<int16_t, DST>(*reinterpret_cast<const int16_t*>( _raw_data), target  ); break;
-  case INT32:  convert_impl<int32_t, DST>(*reinterpret_cast<const int32_t*>( _raw_data), target  ); break;
-  case INT64:  convert_impl<int64_t, DST>(*reinterpret_cast<const int64_t*>( _raw_data), target  ); break;
+  case INT16:  convert_impl<int16_t, DST>(*reinterpret_cast<const int16_t*>( &_raw_data [0]), target  ); break;
+  case INT32:  convert_impl<int32_t, DST>(*reinterpret_cast<const int32_t*>( &_raw_data [0]), target  ); break;
+  case INT64:  convert_impl<int64_t, DST>(*reinterpret_cast<const int64_t*>( &_raw_data [0]), target  ); break;
 
   case BOOL:
   case BYTE:
-  case UINT8:   convert_impl<uint8_t,  DST>(*reinterpret_cast<const uint8_t*>( _raw_data), target  ); break;
+  case UINT8:   convert_impl<uint8_t,  DST>(*reinterpret_cast<const uint8_t*>( &_raw_data [0]), target  ); break;
 
-  case UINT16:  convert_impl<uint16_t, DST>(*reinterpret_cast<const uint16_t*>( _raw_data), target  ); break;
-  case UINT32:  convert_impl<uint32_t, DST>(*reinterpret_cast<const uint32_t*>( _raw_data), target  ); break;
-  case UINT64:  convert_impl<uint64_t, DST>(*reinterpret_cast<const uint64_t*>( _raw_data), target  ); break;
+  case UINT16:  convert_impl<uint16_t, DST>(*reinterpret_cast<const uint16_t*>( &_raw_data [0]), target  ); break;
+  case UINT32:  convert_impl<uint32_t, DST>(*reinterpret_cast<const uint32_t*>( &_raw_data [0]), target  ); break;
+  case UINT64:  convert_impl<uint64_t, DST>(*reinterpret_cast<const uint64_t*>( &_raw_data [0]), target  ); break;
 
-  case FLOAT32:  convert_impl<float, DST>(*reinterpret_cast<const float*>( _raw_data), target  ); break;
-  case FLOAT64:  convert_impl<double, DST>(*reinterpret_cast<const double*>( _raw_data), target  ); break;
-
+  case FLOAT32:  convert_impl<float, DST>(*reinterpret_cast<const float*>( &_raw_data [0]), target  ); break;
+  case FLOAT64:  convert_impl<double, DST>(*reinterpret_cast<const double*>( &_raw_data [0]), target  ); break;
+  
   case DURATION:
   case TIME: {
      throw TypeException("ros::Duration and ros::Time can be converted only to double (will be seconds)");
   } break;
 
-  default:  throw TypeException("VarNumber::convert -> cannot convert type" + std::to_string(_raw_data[8])); break;
+  default:  throw TypeException("Variant::convert -> cannot convert type" + std::to_string(_type)); break;
 
   }
   return  target;
 }
 
-template<> inline double VarNumber::convert() const
+template<> inline double Variant::convert() const
 {
   using namespace RosIntrospection::details;
-  double target;
-
+  double target;  
   //----------
-  switch( _raw_data[8] )
+  switch( _type )
   {
   case CHAR:
-  case INT8:   convert_impl<int8_t,  double>(*reinterpret_cast<const int8_t*>( _raw_data), target  ); break;
+  case INT8:   convert_impl<int8_t,  double>(*reinterpret_cast<const int8_t*>( &_raw_data [0]), target  ); break;
 
-  case INT16:  convert_impl<int16_t, double>(*reinterpret_cast<const int16_t*>( _raw_data), target  ); break;
-  case INT32:  convert_impl<int32_t, double>(*reinterpret_cast<const int32_t*>( _raw_data), target  ); break;
-  case INT64:  convert_impl<int64_t, double>(*reinterpret_cast<const int64_t*>( _raw_data), target  ); break;
+  case INT16:  convert_impl<int16_t, double>(*reinterpret_cast<const int16_t*>( &_raw_data [0]), target  ); break;
+  case INT32:  convert_impl<int32_t, double>(*reinterpret_cast<const int32_t*>( &_raw_data [0]), target  ); break;
+  case INT64:  convert_impl<int64_t, double>(*reinterpret_cast<const int64_t*>( &_raw_data [0]), target  ); break;
 
   case BOOL:
   case BYTE:
-  case UINT8:   convert_impl<uint8_t,  double>(*reinterpret_cast<const uint8_t*>( _raw_data), target  ); break;
+  case UINT8:   convert_impl<uint8_t,  double>(*reinterpret_cast<const uint8_t*>( &_raw_data [0]), target  ); break;
 
-  case UINT16:  convert_impl<uint16_t, double>(*reinterpret_cast<const uint16_t*>( _raw_data), target  ); break;
-  case UINT32:  convert_impl<uint32_t, double>(*reinterpret_cast<const uint32_t*>( _raw_data), target  ); break;
-  case UINT64:  convert_impl<uint64_t, double>(*reinterpret_cast<const uint64_t*>( _raw_data), target  ); break;
+  case UINT16:  convert_impl<uint16_t, double>(*reinterpret_cast<const uint16_t*>( &_raw_data [0]), target  ); break;
+  case UINT32:  convert_impl<uint32_t, double>(*reinterpret_cast<const uint32_t*>( &_raw_data [0]), target  ); break;
+  case UINT64:  convert_impl<uint64_t, double>(*reinterpret_cast<const uint64_t*>( &_raw_data [0]), target  ); break;
 
-  case FLOAT32:  convert_impl<float, double>(*reinterpret_cast<const float*>( _raw_data), target  ); break;
-  case FLOAT64:  convert_impl<double, double>(*reinterpret_cast<const double*>( _raw_data), target  ); break;
+  case FLOAT32:  convert_impl<float, double>(*reinterpret_cast<const float*>( &_raw_data [0]), target  ); break;
+  case FLOAT64:  convert_impl<double, double>(*reinterpret_cast<const double*>( &_raw_data [0]), target  ); break;
 
   case DURATION: {
     ros::Duration tmp =  extract<ros::Duration>();
@@ -163,26 +225,35 @@ template<> inline double VarNumber::convert() const
     target = tmp.toSec();
   }break;
     
-  default:  throw TypeException("VarNumber::convert -> cannot convert type" + std::to_string(_raw_data[8])); break;
+  default:  throw TypeException("Variant::convert -> cannot convert type" + std::to_string(_type)); break;
 
   }
   return  target;
 }
 
-template<> inline ros::Time VarNumber::convert() const
+template<> inline SString Variant::convert() const
 {
-  if(  _raw_data[8] != TIME )
+  if(  _type != STRING )
   {
-     throw TypeException("VarNumber::convert -> cannot convert ros::Time");
+     throw TypeException("Variant::convert -> cannot convert String");
+  }
+  return extract<SString>();
+}
+
+template<> inline ros::Time Variant::convert() const
+{
+  if(  _type != TIME )
+  {
+     throw TypeException("Variant::convert -> cannot convert ros::Time");
   }
   return extract<ros::Time>();
 }
 
-template<> inline ros::Duration VarNumber::convert() const
+template<> inline ros::Duration Variant::convert() const
 {
-  if(  _raw_data[8] != TIME )
+  if(  _type != TIME )
   {
-     throw TypeException("VarNumber::convert -> cannot convert ros::Duration");
+     throw TypeException("Variant::convert -> cannot convert ros::Duration");
   }
   return extract<ros::Duration>();
 }

--- a/src/deserializer.cpp
+++ b/src/deserializer.cpp
@@ -57,17 +57,7 @@ void buildRosFlatTypeImpl(const ROSTypeList& type_list,
 
   std::function<void(StringTreeLeaf, bool)> deserializeAndStore;
 
-  if( type.typeID() == STRING )
-  {
-    deserializeAndStore = [&flat_container, &buffer_ptr](StringTreeLeaf tree_node, bool store)
-    {
-      size_t string_size = (size_t) ReadFromBuffer<int32_t>( buffer_ptr );
-      SString id( (const char*)(*buffer_ptr), string_size );
-      (*buffer_ptr) += string_size;
-      if( store ) flat_container->name.push_back( std::make_pair( std::move(tree_node), id ) );
-    };
-  }
-  else if( type.isBuiltin())
+  if( type.isBuiltin())
   {
     deserializeAndStore = [&flat_container, &buffer_ptr, type](StringTreeLeaf tree_node, bool store)
     {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -211,6 +211,11 @@ ROSType::ROSType(const std::string &name):
   }
   else if(_msg_name.compare( "string" ) == 0 ) {
     _id = RosIntrospection::STRING;
+    _deserialize_impl = [](uint8_t** buffer) {
+      size_t string_size = (size_t) ReadFromBuffer<int32_t>(buffer);
+      SString id( (const char*)(*buffer), string_size );
+      return id;
+    };
   }
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -214,6 +214,7 @@ ROSType::ROSType(const std::string &name):
     _deserialize_impl = [](uint8_t** buffer) {
       size_t string_size = (size_t) ReadFromBuffer<int32_t>(buffer);
       SString id( (const char*)(*buffer), string_size );
+      (*buffer) += string_size;
       return id;
     };
   }

--- a/src/renamer.cpp
+++ b/src/renamer.cpp
@@ -276,7 +276,7 @@ void applyNameTransform(const std::vector<SubstitutionRule> &rules,
   {
     if( substituted[i] == false)
     {
-      const std::pair<StringTreeLeaf, VarNumber> & value_leaf = container.value[i];
+      const std::pair<StringTreeLeaf, Variant> & value_leaf = container.value[i];
 
       std::string& destination = renamed_value[renamed_index].first;
       value_leaf.first.toStr( destination );

--- a/src/tests/benchmark.cpp
+++ b/src/tests/benchmark.cpp
@@ -74,12 +74,12 @@ int main( int argc, char** argv)
     ROSType main_type (DataType<sensor_msgs::JointState>::value());
 
     auto rules = Rules();
-
+    RenamedValues renamed_values;
     ROSTypeFlat flat_container;
     for (int i=0; i<100*1000;i++)
     {
-        buildRosFlatType(type_map,main_type, "joint_state", buffer.data(), &flat_container);
-        applyNameTransform( rules , &flat_container );
+        buildRosFlatType(type_map,main_type, "joint_state", buffer.data(), &flat_container, 100);
+        applyNameTransform( rules , flat_container , renamed_values);
     }
 
     auto end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
The benchmark shows that this approach is 50% slower than the 2 vectors approach (in my laptop it takes 4600 vs 3000). I rely on boost::any to store all data without casting all numbers to doubles. Also the data container was decoupled from the type (until now stored in a uint_8 array with dimension 9).  A vector is used for the data and a variable called _type to store the type.
I also added a function called auto_convert that automatically chooses what cast type to use and put it into a boost::any output variable.
For reading the data (in a callback for example) a switch depending on the type of the variable should be used combined with boost::any_cast. I did not find a better solution until now.