### PR TITLE
When converting type, checkTruncation throws when input is nan

### DIFF
--- a/include/ros_type_introspection/details/conversion_impl.hpp
+++ b/include/ros_type_introspection/details/conversion_impl.hpp
@@ -154,7 +154,7 @@ inline void checkLowerLimit(const From& from)
 template <typename From, typename To>
 inline void checkTruncation(const From& from)
 {
-  if( from != static_cast<From>(static_cast<To>( from))){
+  if(!std::isnan(from) && (from != static_cast<From>(static_cast<To>( from)))) {
     throw RangeException("Floating point truncated");
   }
 }


### PR DESCRIPTION
The equality check for nan always returns false which caused checkTruncation to throw "Floating point truncated" exception. Happened when loading a ROS bag in PlotJuggler containing nans in some messages.