### PR TITLE
fixed -Wreorder in ros_introspection.hpp

### DIFF
--- a/include/ros_type_introspection/ros_introspection.hpp
+++ b/include/ros_type_introspection/ros_introspection.hpp
@@ -64,7 +64,7 @@ typedef std::vector< std::pair<std::string, Variant> > RenamedValues;
 class Parser{
 
 public:
-  Parser(): _global_warnings(&std::cerr), _rule_cache_dirty(true) {}
+  Parser(): _rule_cache_dirty(true), _global_warnings(&std::cerr) {}
 
   /**
    * @brief A single message definition will (most probably) generate myltiple ROSMessage(s).


### PR DESCRIPTION
The now swapped variables were initialized in a different order than they were declared. On my compiler this triggered the warning -Wreorder, which prevented me to compile with warnings treated as errors.

With this change, client code should be able to compile with -Werror.