### PR TITLE
Add missing BuiltinType::getType() overloads

### DIFF
--- a/include/ros_type_introspection/builtin_types.hpp
+++ b/include/ros_type_introspection/builtin_types.hpp
@@ -115,6 +115,9 @@ template <typename T> BuiltinType getType()
 
 template <> inline BuiltinType getType<bool>()  {  return BOOL; }
 
+template <> inline BuiltinType getType<unsigned char>()  {  return BYTE; }
+template <> inline BuiltinType getType<char>()           {  return CHAR; }
+
 template <> inline BuiltinType getType<int8_t>()  {  return INT8; }
 template <> inline BuiltinType getType<int16_t>() {  return INT16; }
 template <> inline BuiltinType getType<int32_t>() {  return INT32; }


### PR DESCRIPTION
Some types are not supported for extraction.

[`BuiltinType`](https://github.com/facontidavide/ros_type_introspection/blob/5b71ac2aa3c06e0d83da21313b0544a80012e8ec/include/ros_type_introspection/builtin_types.hpp) is missing two [`getType()`](https://github.com/facontidavide/ros_type_introspection/blob/5b71ac2aa3c06e0d83da21313b0544a80012e8ec/include/ros_type_introspection/builtin_types.hpp#L111-L134) functions, namely for `BYTE` and `CHAR` which currently resolve to `OTHER` (as they are not overloaded like the other types) which prevents the correct type comparison in [`Variant::extract()`](https://github.com/facontidavide/ros_type_introspection/blob/master/include/ros_type_introspection/utils/variant.hpp#L176).

This PR adds those overloads. However, some stuff might be debatable:
- I overloaded `BYTE` using `unsigned char`. Another possibility is using the C++17 [`std::byte`](https://en.cppreference.com/w/cpp/types/byte) class which is not as backwards compatible but semantically nicer.
- `CHAR` is overloaded using `char`. This makes semantic sense but has one quirk: `char` can be a `signed char` or `unsigned char` (the same type as `BYTE`, although distinct in the sense that it does not break the template).
  I cannot think of when it could be problematic but there may be cases.