### PR TITLE
Fix missing inline keyword for ShapeShifter::size()

### DIFF
--- a/include/ros_type_introspection/utils/shape_shifter.hpp
+++ b/include/ros_type_introspection/utils/shape_shifter.hpp
@@ -220,7 +220,7 @@ inline const uint8_t* ShapeShifter::raw_data() const {
   return msgBuf_.data();
 }
 
-uint32_t ShapeShifter::size() const
+inline uint32_t ShapeShifter::size() const
 {
   return msgBuf_.size();
 }


### PR DESCRIPTION
The missing inline keyword creates multiple (albeit same) definitions of the size() function when compiling multiple source files that #include shape_shifter.hpp, causing the linker to fail.

The change allows the linking to succeed.