### PR TITLE
fix compiler warnings

### DIFF
--- a/include/ros_type_introspection/helper_functions.hpp
+++ b/include/ros_type_introspection/helper_functions.hpp
@@ -152,6 +152,7 @@ inline Variant ReadFromBufferToVariant(BuiltinType id, const absl::Span<uint8_t>
     return var_string;
   }
   case OTHER: return -1;
+  default: break;
   }
   throw std::runtime_error( "unsupported builtin type value");
 }

--- a/src/ros_introspection.cpp
+++ b/src/ros_introspection.cpp
@@ -380,7 +380,7 @@ bool Parser::deserializeIntoFlatContainer(const std::string& msg_identifier,
       bool IS_BLOB = false;
 
       // Stop storing it it is NOT a blob and a very large array.
-      if( array_size > max_array_size)
+      if( array_size > static_cast<int32_t>(max_array_size))
       {
         if( field_type.typeID() == UINT8){
           IS_BLOB = true;


### PR DESCRIPTION
This just fixes some compiler warnings:
```
In file included from /homes/rhaschke/src/ros/src/moveit/ros_type_introspection/src/ros_introspection.cpp:43:0:
/homes/rhaschke/src/ros/src/moveit/ros_type_introspection/include/ros_type_introspection/helper_functions.hpp: In function ‘RosIntrospection::Variant RosIntrospection::ReadFromBufferToVariant(RosIntrospection::BuiltinType, const absl::Span<unsigned char>&, size_t&)’:
/homes/rhaschke/src/ros/src/moveit/ros_type_introspection/include/ros_type_introspection/helper_functions.hpp:114:9: warning: enumeration value ‘CHAR’ not handled in switch [-Wswitch]
   switch(id)
         ^
/homes/rhaschke/src/ros/src/moveit/ros_type_introspection/src/ros_introspection.cpp: In lambda function:
/homes/rhaschke/src/ros/src/moveit/ros_type_introspection/src/ros_introspection.cpp:383:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if( array_size > max_array_size)
           ~~~~~~~~~~~^~~~~~~~~~~~~~~~

```