### PR TITLE
[MSVC] Drop constexpr on absl::string_view to avoid build break

### DIFF
--- a/include/ros_type_introspection/stringtree_leaf.hpp
+++ b/include/ros_type_introspection/stringtree_leaf.hpp
@@ -99,7 +99,7 @@ struct StringTreeLeaf{
   constexpr static const char NUM_PLACEHOLDER = '#';
 
   static const absl::string_view& num_placeholder() {
-    constexpr static const absl::string_view nph("#");
+    static const absl::string_view nph("#");
     return nph;
   }
 };


### PR DESCRIPTION
When building `ros_type_introspection` on Windows by MSVC, the usage of `constexpr` on `absl::string_view` caused the following build break:

```
ros_type_introspection\include\ros_type_introspection/stringtree_leaf.hpp(102): error C2131: expression did not evaluate to a constant
abseil-cpp\abseil_cpp\absl/strings/string_view.h(186): note: a non-constant (sub-)expression was encountered
```

A similar issue was also reported on https://github.com/abseil/abseil-cpp/issues/352. For now, before a better solution comes out, I recommend to drop `constexpr` to avoid build break.