### PR TITLE
Make introspection resilient to white spaces in line starts of message definitions

### DIFF
--- a/src/ros_introspection.cpp
+++ b/src/ros_introspection.cpp
@@ -197,7 +197,7 @@ void Parser::registerMessageDefinition(const std::string &msg_definition,
   }
   _rule_cache_dirty = true;
 
-  const boost::regex msg_separation_regex("^=+\\n+");
+  const boost::regex msg_separation_regex("^\\s*=+\\n+");
 
   std::vector<std::string> split;
   std::vector<const ROSType*> all_types;

--- a/src/ros_message.cpp
+++ b/src/ros_message.cpp
@@ -58,6 +58,10 @@ ROSMessage::ROSMessage(const std::string &msg_def)
       continue;
     }
 
+    // Trim start of line
+    line.erase(line.begin(), std::find_if(line.begin(), line.end(),
+      std::not1(std::ptr_fun<int, int>(std::isspace))));
+
     if( line.compare(0, 5, "MSG: ") == 0)
     {
       line.erase(0,5);


### PR DESCRIPTION
Message definitions generated by gennodejs contain white spaces at each line start. Messages generated from js code (in my case from rosnodejs) cannot be displayed in PlotJuggler because type introspection fails.